### PR TITLE
Python 3 Compatibility

### DIFF
--- a/octoprint_prettygcode/__init__.py
+++ b/octoprint_prettygcode/__init__.py
@@ -38,6 +38,7 @@ class PrettyGCodePlugin(octoprint.plugin.StartupPlugin,
 # ("OctoPrint-PluginSkeleton"), you may define that here. Same goes for the other metadata derived from setup.py that
 # can be overwritten via __plugin_xyz__ control properties. See the documentation for that.
 __plugin_name__ = "PrettyGCode"
+__plugin_pythoncompat__ = ">=2.7,<4"
 def __plugin_load__():
     global __plugin_implementation__ 
     __plugin_implementation__ = PrettyGCodePlugin()


### PR DESCRIPTION
There were no issues with my testing in Python 3, you just need to add the flag, and then make sure that when you register with the plugin repository that you do the same.