### PR TITLE
Allow camera to be below the horizon

### DIFF
--- a/octoprint_prettygcode/static/js/prettygcode.js
+++ b/octoprint_prettygcode/static/js/prettygcode.js
@@ -1670,6 +1670,7 @@ $(function () {
 
             var canvas = $("#mycanvas");
             cameraControls = new CameraControls(camera, canvas[0]);
+            cameraControls.maxPolarAngle = Math.PI;
 
             //todo handle other than lowerleft
             resetCamera();


### PR DESCRIPTION
I find that sometimes it is useful to view the print from below. To do this I set the cameraControls.maxPolarAngle to pi, effectively removing the restriction.