### PR TITLE
Fix non-CSS-targetable text

### DIFF
--- a/octoprint_prettygcode/templates/prettygcode_tab.jinja2
+++ b/octoprint_prettygcode/templates/prettygcode_tab.jinja2
@@ -18,10 +18,10 @@
 </div>
 
 <h3 id="injector_link">PrettyGCode</h3>
-A GCode visualizer.
+<div>A GCode visualizer.</div>
 <br>
 <br>
-You can open directly in fullscreen mode by using the link below.<br>
+<div>You can open directly in fullscreen mode by using the link below.</div><br>
 <a id="fs_link" href="/?fullscreen=1#tab_plugin_prettygcode">Direct link to fullscreen mode</a>
 <br>
 <button id="pginstructions_button" onClick='$("#pginstructions").toggle();'>Show/Hide Instructions</button>


### PR DESCRIPTION
Added div tags to the loose text in the tab descriptor so that it can be properly targeted by custom CSS